### PR TITLE
remove cerbere dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.6
 
 Package: pantheon-xsession-settings
 Architecture: all
-Depends: io.elementary.cerbere (>= 0.2.4), gnome-session-bin, gala (>= 0.3.2~), pantheon-shell, ${misc:Depends}
+Depends: gnome-session-bin, gala (>= 0.3.2~), pantheon-shell, ${misc:Depends}
 Description: Pantheon session for login screen
  This package installs a fully usable X login session and provides some
  session-specific configuration files and defaults. Installing this package will


### PR DESCRIPTION
Remove cerbere from `pantheon-xsession-settings` dependency requirements.

I'm not certain that this is the only thing required to drop cerbere (whenever we're ready to). Do we also need to blacklist the package as well, or will `apt autoremove` mark the package as obsolete after dropping the dependency?