### PR TITLE
Fix GSD autostart paths

### DIFF
--- a/autostart/gsd/org.gnome.SettingsDaemon.A11ySettings-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.A11ySettings-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's a11y-settings plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-a11y-settings
+Exec=/usr/libexec/gsd-a11y-settings
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Clipboard-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Clipboard-pantheon.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=GNOME Settings Daemon's clipboard plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-clipboard
-OnlyShowIn=Pantheon;
-NoDisplay=true
-X-GNOME-Autostart-Phase=Initialization
-X-GNOME-Autostart-Notify=true
-X-GNOME-AutoRestart=true

--- a/autostart/gsd/org.gnome.SettingsDaemon.Color-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Color-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's color plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-color
+Exec=/usr/libexec/gsd-color
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Datetime-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Datetime-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's datetime plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-datetime
+Exec=/usr/libexec/gsd-datetime
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Housekeeping-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Housekeeping-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's housekeeping plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-housekeeping
+Exec=/usr/libexec/gsd-housekeeping
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Keyboard-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Keyboard-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's keyboard plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-keyboard
+Exec=/usr/libexec/gsd-keyboard
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.MediaKeys-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.MediaKeys-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's media-keys plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-media-keys
+Exec=/usr/libexec/gsd-media-keys
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Mouse-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Mouse-pantheon.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=GNOME Settings Daemon's mouse plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-mouse
-OnlyShowIn=Pantheon;
-NoDisplay=true
-X-GNOME-Autostart-Phase=Initialization
-X-GNOME-Autostart-Notify=true
-X-GNOME-AutoRestart=true

--- a/autostart/gsd/org.gnome.SettingsDaemon.Power-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Power-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's power plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-power
+Exec=/usr/libexec/gsd-power
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.PrintNotifications-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.PrintNotifications-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's print-notifications plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-print-notifications
+Exec=/usr/libexec/gsd-print-notifications
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Rfkill-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Rfkill-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's rfkill plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-rfkill
+Exec=/usr/libexec/gsd-rfkill
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Sharing-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Sharing-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's sharing plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-sharing
+Exec=/usr/libexec/gsd-sharing
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Smartcard-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Smartcard-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's smartcard plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-smartcard
+Exec=/usr/libexec/gsd-smartcard
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Sound-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Sound-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's sound plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-sound
+Exec=/usr/libexec/gsd-sound
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.Wacom-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.Wacom-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's wacom plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-wacom
+Exec=/usr/libexec/gsd-wacom
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization

--- a/autostart/gsd/org.gnome.SettingsDaemon.XSettings-pantheon.desktop
+++ b/autostart/gsd/org.gnome.SettingsDaemon.XSettings-pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=GNOME Settings Daemon's xsettings plugin
-Exec=/usr/lib/gnome-settings-daemon/gsd-xsettings
+Exec=/usr/libexec/gsd-xsettings
 OnlyShowIn=Pantheon;
 NoDisplay=true
 X-GNOME-Autostart-Phase=Initialization


### PR DESCRIPTION
GSD executables are now installed to `/usr/libexec` , I've also deleted the two autostarts for the ones that don't exist anymore