### PR TITLE
Interim proposal: use --builtin until systemd session management is fully implemented.

### DIFF
--- a/xsessions/pantheon.desktop
+++ b/xsessions/pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Pantheon
 Comment=This session provides elementary experience
-Exec=gnome-session --session=pantheon
+Exec=gnome-session --builtin --session=pantheon
 TryExec=wingpanel
 Icon=
 DesktopNames=Pantheon


### PR DESCRIPTION
Since we already have the [.desktop files for wingpanel and plank](https://github.com/elementary/cerbere/issues/36#issuecomment-573627648), but [systemd managment is still in development](https://github.com/elementary/session-settings/issues/17); we could _temporarily_ work around cerbere, at least for users of the development tip, by adding `--builtin`.

It's also (theoretically) possible systemd managment will not be ready for the next release cycle. A release with `--builtin` may help users transition away from cerbere.