### PR TITLE
Map Pantheon required components by g-s-d versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,16 +6,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     container:
       image: elementary/docker:unstable
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y meson
+        apt install -y meson pkg-config gnome-settings-daemon-dev
     - name: Build
       run: |
         meson build

--- a/gnome-session/meson.build
+++ b/gnome-session/meson.build
@@ -3,6 +3,57 @@ fallback_session = get_option('fallback-session')
 session_configuration = configuration_data()
 session_configuration.set('FALLBACK_SESSION', fallback_session)
 
+pantheon_components = [
+  'gala',
+  'gala-daemon',
+]
+
+gsd_components = [
+  'org.gnome.SettingsDaemon.A11ySettings',
+  'org.gnome.SettingsDaemon.Color',
+  'org.gnome.SettingsDaemon.Datetime',
+  'org.gnome.SettingsDaemon.Housekeeping',
+  'org.gnome.SettingsDaemon.Keyboard',
+  'org.gnome.SettingsDaemon.MediaKeys',
+  'org.gnome.SettingsDaemon.Power',
+  'org.gnome.SettingsDaemon.PrintNotifications',
+  'org.gnome.SettingsDaemon.Rfkill',
+  'org.gnome.SettingsDaemon.Sharing',
+  'org.gnome.SettingsDaemon.Smartcard',
+  'org.gnome.SettingsDaemon.Sound',
+  'org.gnome.SettingsDaemon.Wacom',
+  'org.gnome.SettingsDaemon.XSettings',
+]
+
+# Removed in 3.33.90
+# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/863ff3c8e3a64ef6dc6ecd0c243699b598484b44
+# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/01f27ed6e501bfd66a7e725a1ca1b452f52fcf07
+gsd_mouse_clipboard = [
+  'org.gnome.SettingsDaemon.Clipboard',
+  'org.gnome.SettingsDaemon.Mouse',
+]
+
+# Added in 3.36.0
+# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/86d4132c7810b5c1b2392f63c15b3b90b8a7a4f9
+gsd_usb_protection = ['org.gnome.SettingsDaemon.UsbProtection']
+
+# Needs a minimum 3.28 GNOME stack
+gsd_minimum_version = '>= 3.27.90'
+
+gsd_dep = dependency('gnome-settings-daemon', version: gsd_minimum_version)
+gsd_version = gsd_dep.version()
+
+# Merge the list depending on the gnome-settings-daemon version.
+if gsd_version.version_compare('>=3.36.0')
+  session_components = pantheon_components + gsd_components + gsd_usb_protection
+elif gsd_version.version_compare('>=3.33.90')
+  session_components = pantheon_components + gsd_components
+else
+  session_components = pantheon_components + gsd_components + gsd_mouse_clipboard
+endif
+
+session_configuration.set('SESSION_COMPONENTS', ';'.join(session_components))
+
 pantheon_session = configure_file(
   input: 'pantheon.session.in',
   output: '@BASENAME@',

--- a/gnome-session/pantheon.session.in
+++ b/gnome-session/pantheon.session.in
@@ -1,5 +1,5 @@
 [GNOME Session]
 Name=Pantheon
-RequiredComponents=gala;gala-daemon;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Clipboard;org.gnome.SettingsDaemon.Color;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Mouse;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;
+RequiredComponents=@SESSION_COMPONENTS@
 FallbackSession=@FALLBACK_SESSION@
 DesktopName=Pantheon


### PR DESCRIPTION
To continue to support Pantheon with a newer g-s-d version in NixOS I needed to manually ship a different session file because of changes made in gnome-settings-daemon.
Let's make session-settings generate the pantheon.session with mappings to what components will be available in g-s-d by its version. This PR is inspired by what is already done in [budgie-desktop](https://github.com/solus-project/budgie-desktop/blob/979c151f51c40952d3fc7cb26d9e3ad34f640ac3/src/session/meson.build). The minimum supported g-s-d version is `>= 3.27.90`, which is the GNOME 3.28 stack in the Ubuntu LTS. I will continue to make adjustments as new versions of g-s-d are released.