### PR TITLE
Ship a patched light-locker autostart

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,16 +6,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     container:
       image: elementary/docker:unstable
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y meson
+        apt install -y meson pkg-config gnome-settings-daemon-dev
     - name: Build
       run: |
         meson build

--- a/autostart/light-locker/light-locker-pantheon.desktop
+++ b/autostart/light-locker/light-locker-pantheon.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=Screen Locker
+Comment=Launch screen locker program
+Icon=preferences-desktop-screensaver
+Exec=light-locker
+NoDisplay=true
+NotShowIn=GNOME;Unity;
+OnlyShowIn=Pantheon;
+X-GNOME-AutoRestart=true
+X-GNOME-Autostart-Notify=true
+X-GNOME-Autostart-Phase=Desktop

--- a/autostart/meson.build
+++ b/autostart/meson.build
@@ -16,3 +16,9 @@ if get_option('patched-ubuntu-autostarts')
         strip_directory: true
     )
 endif
+
+install_subdir(
+    'light-locker',
+    install_dir: autostartdir,
+    strip_directory: true
+)

--- a/gnome-session/meson.build
+++ b/gnome-session/meson.build
@@ -6,6 +6,7 @@ session_configuration.set('FALLBACK_SESSION', fallback_session)
 pantheon_components = [
   'gala',
   'gala-daemon',
+  'light-locker-pantheon',
 ]
 
 gsd_components = [

--- a/gnome-session/meson.build
+++ b/gnome-session/meson.build
@@ -3,6 +3,57 @@ fallback_session = get_option('fallback-session')
 session_configuration = configuration_data()
 session_configuration.set('FALLBACK_SESSION', fallback_session)
 
+pantheon_components = [
+  'gala',
+  'gala-daemon',
+]
+
+gsd_components = [
+  'org.gnome.SettingsDaemon.A11ySettings',
+  'org.gnome.SettingsDaemon.Color',
+  'org.gnome.SettingsDaemon.Datetime',
+  'org.gnome.SettingsDaemon.Housekeeping',
+  'org.gnome.SettingsDaemon.Keyboard',
+  'org.gnome.SettingsDaemon.MediaKeys',
+  'org.gnome.SettingsDaemon.Power',
+  'org.gnome.SettingsDaemon.PrintNotifications',
+  'org.gnome.SettingsDaemon.Rfkill',
+  'org.gnome.SettingsDaemon.Sharing',
+  'org.gnome.SettingsDaemon.Smartcard',
+  'org.gnome.SettingsDaemon.Sound',
+  'org.gnome.SettingsDaemon.Wacom',
+  'org.gnome.SettingsDaemon.XSettings',
+]
+
+# Removed in 3.33.90
+# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/863ff3c8e3a64ef6dc6ecd0c243699b598484b44
+# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/01f27ed6e501bfd66a7e725a1ca1b452f52fcf07
+gsd_mouse_clipboard = [
+  'org.gnome.SettingsDaemon.Clipboard',
+  'org.gnome.SettingsDaemon.Mouse',
+]
+
+# Added in 3.36.0
+# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/86d4132c7810b5c1b2392f63c15b3b90b8a7a4f9
+gsd_usb_protection = ['org.gnome.SettingsDaemon.UsbProtection']
+
+# Needs a minimum 3.28 GNOME stack
+gsd_minimum_version = '>= 3.27.90'
+
+gsd_dep = dependency('gnome-settings-daemon', version: gsd_minimum_version)
+gsd_version = gsd_dep.version()
+
+# Merge the list depending on the gnome-settings-daemon version.
+if gsd_version.version_compare('>=3.36.0')
+  session_components = pantheon_components + gsd_components + gsd_usb_protection
+elif gsd_version.version_compare('>=3.33.90')
+  session_components = pantheon_components + gsd_components
+else
+  session_components = pantheon_components + gsd_components + gsd_mouse_clipboard
+endif
+
+session_configuration.set('SESSION_COMPONENTS', ';'.join(session_components))
+
 pantheon_session = configure_file(
   input: 'pantheon.session.in',
   output: '@BASENAME@',

--- a/gnome-session/pantheon.session.in
+++ b/gnome-session/pantheon.session.in
@@ -1,5 +1,5 @@
 [GNOME Session]
 Name=Pantheon
-RequiredComponents=gala;gala-daemon;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Clipboard;org.gnome.SettingsDaemon.Color;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Mouse;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;
+RequiredComponents=@SESSION_COMPONENTS@
 FallbackSession=@FALLBACK_SESSION@
 DesktopName=Pantheon


### PR DESCRIPTION
**This depends on https://github.com/elementary/session-settings/pull/23.**

We fix https://github.com/elementary/session-settings/issues/26 by shipping a patched light-locker autostart, and adding it to RequiredComponents. If light-locker were to be killed or segfault it is now restarted.

**You can test this by doing:**
1. Does the Pantheon session still start?
It won't be able to if it can't bring up `light-locker-pantheon.desktop`
2. Is light-locker running?
3. Can you kill light-locker and it is restarted?
The easiest way is to send it `SIGSEGV` like:
```
pkill -SIGSEGV light-locker
```