### PR TITLE
control: Add gnome-settings-daemon-dev build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: pantheon-xsession-settings
 Section: x11
 Priority: optional
 Maintainer: Cody Garver <cody@elementary.io>
-Build-Depends: debhelper (>= 9), meson
+Build-Depends: debhelper (>= 9), meson, gnome-settings-daemon-dev
 Standards-Version: 3.9.6
 
 Package: pantheon-xsession-settings


### PR DESCRIPTION
Seeing build failures here, looks like it's due to missing g-s-d:
https://launchpadlibrarian.net/495308445/buildlog_ubuntu-focal-amd64.pantheon-xsession-settings_5.0.3-0+r128+pkg122~daily~ubuntu6.0.1_BUILDING.txt.gz