### PR TITLE
meson: Reduce scope of find_program variables

### DIFF
--- a/session/meson.build
+++ b/session/meson.build
@@ -98,11 +98,11 @@ foreach component : gsd_components
   )
 endforeach
 
-gnome_keyring = find_program('gnome-keyring-daemon')
-onboard = find_program('onboard')
-orca = find_program('orca')
-
 if get_option('detect-program-prefixes') == true
+  gnome_keyring = find_program('gnome-keyring-daemon')
+  onboard = find_program('onboard')
+  orca = find_program('orca')
+
   # TODO: use fs module in meson 0.53.0
   gnome_keyring_prefix = gnome_keyring.path().split('/bin')[0]
   onboard_prefix = onboard.path().split('/bin')[0]


### PR DESCRIPTION
These are only needed if the `detect-program-prefixes` option is set.

We don't use this option in elementary, so lets reduce the scope of these variables so they don't need to be installed to get the thing to build.