### PR TITLE
Add systemd support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,3 +11,7 @@ endif
 
 subdir('session')
 subdir('xsessions')
+
+if get_option('systemd')
+    subdir('systemd')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,6 @@ option('fallback-session', type : 'string', value: 'ubuntu',
 
 option('detect-program-prefixes', type: 'boolean', value: false,
        description : 'This is needed for platforms that install packages into individual prefixes (like Guix System or NixOS')
+
+option('systemd', type: 'boolean', value: true,
+       description : 'Install systemd unit files for managing the Pantheon session with gnome-session systemd support')

--- a/systemd/gnome-session-x11@pantheon.target
+++ b/systemd/gnome-session-x11@pantheon.target
@@ -1,0 +1,22 @@
+[Unit]
+Description=GNOME X11 Session (session: %i)
+OnFailure=gnome-session-failed.target
+OnFailureJobMode=replace
+DefaultDependencies=no
+# Start happens explicitly
+RefuseManualStart=no
+# Stop happens by starting gnome-session-shutdown.target
+#RefuseManualStop=yes
+
+Conflicts=shutdown.target gnome-session-shutdown.target
+PartOf=graphical-session.target
+
+# As this is the main entry point, pull in the other toplevel gnome-session targets
+BindsTo=gnome-session@.target
+After=gnome-session@.target
+
+BindsTo=pantheon-session-x11.target
+After=pantheon-session-x11.target
+
+BindsTo=gnome-session.target
+After=gnome-session.target

--- a/systemd/meson.build
+++ b/systemd/meson.build
@@ -1,0 +1,12 @@
+dep_systemd = dependency('systemd', required: true)
+systemd_userunitdir = dep_systemd.get_pkgconfig_variable('systemduserunitdir')
+
+install_data(
+    'gnome-session-x11@pantheon.target',
+    install_dir: systemd_userunitdir
+)
+
+install_data(
+    'pantheon-session-x11.target',
+    install_dir: systemd_userunitdir
+)

--- a/systemd/pantheon-session-x11.target
+++ b/systemd/pantheon-session-x11.target
@@ -1,0 +1,20 @@
+[Unit]
+Description=Pantheon X11 Session
+# On X11, try to show the fail screen
+OnFailure=gnome-session-failed.target
+OnFailureJobMode=replace
+# Avoid default After/Before rules
+DefaultDependencies=no
+
+Before=gnome-session.target
+
+PartOf=graphical-session.target
+RefuseManualStart=yes
+RefuseManualStop=yes
+
+# Pull in all X11-specific services the session might depend on
+Requires=gnome-session-x11-services.target
+
+# Pull in the correct gala target
+BindsTo=gala-x11.target
+After=gala-x11.target


### PR DESCRIPTION
Adds the necessary unit files to be able to launch Pantheon via `gnome-session`'s systemd support.

Merging this will have no effect on the current way of launching the session, just prepares us for removing the `--builtin` flag on the session in the future.

This can be tested in conjunction with https://github.com/elementary/gala/pull/1256 and https://github.com/elementary/gala/pull/1255 . If you remove the `--builtin` flag from `/usr/share/xsessions/pantheon.desktop`, `gnome-session` will launch Pantheon using the systemd units instead of the XDG autostarts.