### PR TITLE
build: add systemduserunitdir option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,3 +9,6 @@ option('detect-program-prefixes', type: 'boolean', value: false,
 
 option('systemd', type: 'boolean', value: true,
        description : 'Install systemd unit files for managing the Pantheon session with gnome-session systemd support')
+
+option('systemduserunitdir', type: 'string', value: '',
+       description : 'Custom directory for systemd user units')

--- a/systemd/meson.build
+++ b/systemd/meson.build
@@ -1,5 +1,8 @@
 dep_systemd = dependency('systemd', required: true)
-systemd_userunitdir = dep_systemd.get_pkgconfig_variable('systemduserunitdir')
+systemd_userunitdir = get_option('systemduserunitdir')
+if systemd_userunitdir == ''
+    systemd_userunitdir = dep_systemd.get_pkgconfig_variable('systemduserunitdir', define_variable: ['prefix', get_option('prefix')])
+endif
 
 install_data(
     'gnome-session-x11@pantheon.target',


### PR DESCRIPTION
Actually this is a copy-paste of https://github.com/elementary/gala/commit/78a5f881ba329ea28ade0c3c91fe18521135877a,
I really want to drop the `PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR` hack in NixOS packaging.