### PR TITLE
systemd: also pull in GSD targets

### DIFF
--- a/systemd/gnome.session.conf.in
+++ b/systemd/gnome.session.conf.in
@@ -1,0 +1,4 @@
+[Unit]
+@wants_required_components@
+
+Requires=@requires_component@.target

--- a/systemd/meson.build
+++ b/systemd/meson.build
@@ -10,3 +10,45 @@ install_data(
     'pantheon-session-x11.target',
     install_dir: systemd_userunitdir
 )
+
+desktop_plain = 'pantheon'
+
+shell_component = {
+    desktop_plain: 'gala-x11',
+}
+
+required_components = {
+    desktop_plain: [
+        'org.gnome.SettingsDaemon.A11ySettings',
+        'org.gnome.SettingsDaemon.Color',
+        'org.gnome.SettingsDaemon.Datetime',
+        'org.gnome.SettingsDaemon.Housekeeping',
+        'org.gnome.SettingsDaemon.Keyboard',
+        'org.gnome.SettingsDaemon.MediaKeys',
+        'org.gnome.SettingsDaemon.Power',
+        'org.gnome.SettingsDaemon.PrintNotifications',
+        'org.gnome.SettingsDaemon.Rfkill',
+        'org.gnome.SettingsDaemon.ScreensaverProxy',
+        'org.gnome.SettingsDaemon.Sharing',
+        'org.gnome.SettingsDaemon.Smartcard',
+        'org.gnome.SettingsDaemon.Sound',
+        'org.gnome.SettingsDaemon.UsbProtection',
+        'org.gnome.SettingsDaemon.Wacom',
+        'org.gnome.SettingsDaemon.XSettings',
+    ],
+}
+
+gnome_session_wanted_targets = []
+foreach component: required_components[desktop_plain]
+    gnome_session_wanted_targets += 'Wants=@0@.target'.format(component)
+endforeach
+
+configure_file(
+    input: 'gnome.session.conf.in',
+    output: 'session.conf',
+    configuration: {
+        'requires_component': shell_component[desktop_plain],
+        'wants_required_components': '\n'.join(gnome_session_wanted_targets),
+    },
+    install_dir: systemd_userunitdir / 'gnome-session@pantheon.target.d',
+)


### PR DESCRIPTION
Otherwise these targets don't start correctly on NixOS (without --builtin)

gnome-session handle this as well: https://gitlab.gnome.org/GNOME/gnome-session/-/blob/42.0/data/meson.build#L175