### PR TITLE
Provide onboard-autostart fallback

### DIFF
--- a/session/fallback/onboard-autostart.desktop
+++ b/session/fallback/onboard-autostart.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Onboard
+GenericName=Onboard onscreen keyboard
+Comment=Flexible onscreen keyboard
+Exec=onboard --not-show-in=GNOME,GNOME-Classic:GNOME --startup-delay=3.0
+Icon=onboard
+Type=Application
+NoDisplay=true
+X-Ubuntu-Gettext-Domain=onboard
+AutostartCondition=GSettings org.gnome.desktop.a11y.applications screen-keyboard-enabled
+X-GNOME-AutoRestart=true
+OnlyShowIn=Unity;MATE;

--- a/session/meson.build
+++ b/session/meson.build
@@ -126,7 +126,7 @@ else
 endif
 
 fs = import('fs')
-if fs.is_file(autostarts.get('onboard-autostart'))
+if not fs.is_file(autostarts.get('onboard-autostart'))
   message('Could not find onboard-autostart. Using fallback config.')
   autostarts += {
     'onboard-autostart': join_paths(meson.current_source_dir(), 'fallback', 'onboard-autostart.desktop')

--- a/session/meson.build
+++ b/session/meson.build
@@ -125,6 +125,11 @@ else
   }
 endif
 
+fs = import('fs')
+if fs.is_file(autostarts.get('onboard-autostart'))
+  message('Could not find onboard-autostart. Fallback to local config.')
+endif
+
 foreach name, autostart : autostarts
   custom_target('create-autostart-' + name,
     input: autostart,

--- a/session/meson.build
+++ b/session/meson.build
@@ -127,7 +127,10 @@ endif
 
 fs = import('fs')
 if fs.is_file(autostarts.get('onboard-autostart'))
-  message('Could not find onboard-autostart. Fallback to local config.')
+  message('Could not find onboard-autostart. Using fallback config.')
+  autostarts += {
+    'onboard-autostart': join_paths(meson.current_source_dir(), 'fallback', 'onboard-autostart.desktop')
+  }
 endif
 
 foreach name, autostart : autostarts


### PR DESCRIPTION
Right now we are not able to build session-settings on Fedora 37:

https://github.com/meisenzahl/distro-agnostic/actions/runs/3988175247/jobs/6838977411#step:5:18995

Providing a fallback desktop file fixes this:

https://github.com/meisenzahl/distro-agnostic/actions/runs/4003666637/jobs/6872321011#step:5:18843