### PR TITLE
Remove gala-daemon

### DIFF
--- a/session/meson.build
+++ b/session/meson.build
@@ -5,7 +5,6 @@ session_configuration.set('FALLBACK_SESSION', fallback_session)
 
 pantheon_components = [
   'gala',
-  'gala-daemon',
 ]
 
 gsd_components = [
@@ -68,8 +67,7 @@ pantheon_session = configure_file(
 
 if get_option('wayland')
     wayland_session_components = [
-      'gala-wayland',
-      'gala-daemon',
+      pantheon_components,
       gsd_components
     ]
 

--- a/session/meson.build
+++ b/session/meson.build
@@ -67,7 +67,7 @@ pantheon_session = configure_file(
 
 if get_option('wayland')
     wayland_session_components = [
-      pantheon_components,
+      'gala-wayland,
       gsd_components
     ]
 

--- a/session/meson.build
+++ b/session/meson.build
@@ -67,7 +67,7 @@ pantheon_session = configure_file(
 
 if get_option('wayland')
     wayland_session_components = [
-      'gala-wayland,
+      'gala-wayland',
       gsd_components
     ]
 


### PR DESCRIPTION
I'm not 100% sure whether this is correct but since gala daemon is now started by gala I don't think it belongs in the required components in session settings?