### PR TITLE
Require gnome-settings-daemon 3.36.0 and deduplicate gsd_components

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,27 @@ project('elementary-session-settings',
 prefix = get_option('prefix')
 datadir = join_paths(prefix, get_option('datadir'))
 
+gsd_dep = dependency('gnome-settings-daemon', version: '>= 3.36.0')
+
+gsd_components = [
+    'org.gnome.SettingsDaemon.A11ySettings',
+    'org.gnome.SettingsDaemon.Color',
+    'org.gnome.SettingsDaemon.Datetime',
+    'org.gnome.SettingsDaemon.Housekeeping',
+    'org.gnome.SettingsDaemon.Keyboard',
+    'org.gnome.SettingsDaemon.MediaKeys',
+    'org.gnome.SettingsDaemon.Power',
+    'org.gnome.SettingsDaemon.PrintNotifications',
+    'org.gnome.SettingsDaemon.Rfkill',
+    'org.gnome.SettingsDaemon.ScreensaverProxy',
+    'org.gnome.SettingsDaemon.Sharing',
+    'org.gnome.SettingsDaemon.Smartcard',
+    'org.gnome.SettingsDaemon.Sound',
+    'org.gnome.SettingsDaemon.UsbProtection',
+    'org.gnome.SettingsDaemon.Wacom',
+    'org.gnome.SettingsDaemon.XSettings',
+]
+
 if get_option('mimeapps-list')
     subdir('applications')
 endif

--- a/session/meson.build
+++ b/session/meson.build
@@ -17,42 +17,19 @@ gsd_components = [
   'org.gnome.SettingsDaemon.Power',
   'org.gnome.SettingsDaemon.PrintNotifications',
   'org.gnome.SettingsDaemon.Rfkill',
+  'org.gnome.SettingsDaemon.ScreensaverProxy',
   'org.gnome.SettingsDaemon.Sharing',
   'org.gnome.SettingsDaemon.Smartcard',
   'org.gnome.SettingsDaemon.Sound',
+  'org.gnome.SettingsDaemon.UsbProtection',
   'org.gnome.SettingsDaemon.Wacom',
   'org.gnome.SettingsDaemon.XSettings',
 ]
 
-# Removed in 3.33.90
-# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/863ff3c8e3a64ef6dc6ecd0c243699b598484b44
-# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/01f27ed6e501bfd66a7e725a1ca1b452f52fcf07
-gsd_mouse_clipboard = [
-  'org.gnome.SettingsDaemon.Clipboard',
-  'org.gnome.SettingsDaemon.Mouse',
-]
-
-# Added in 3.36.0
-# https://gitlab.gnome.org/GNOME/gnome-session/-/commit/86d4132c7810b5c1b2392f63c15b3b90b8a7a4f9
-gsd_usb_protection = ['org.gnome.SettingsDaemon.UsbProtection']
-
-# Needed where we're not using light-locker and are using Gala above 3.3.2
-# We're using 3.36 to target this as it's the first elementary release where this is true
-gsd_screensaver_proxy = ['org.gnome.SettingsDaemon.ScreensaverProxy']
-
 # Needs a minimum 3.28 GNOME stack
-gsd_minimum_version = '>= 3.27.90'
+gsd_minimum_version = '>= 3.36.0'
 
 gsd_dep = dependency('gnome-settings-daemon', version: gsd_minimum_version)
-gsd_version = gsd_dep.version()
-
-# Merge the gsd_components list depending on the gnome-settings-daemon version.
-if gsd_version.version_compare('>=3.36.0')
-  gsd_components += gsd_usb_protection
-  gsd_components += gsd_screensaver_proxy
-elif gsd_version.version_compare('< 3.33.90')
-  gsd_components += gsd_mouse_clipboard
-endif
 
 session_components = pantheon_components + gsd_components
 

--- a/session/meson.build
+++ b/session/meson.build
@@ -3,35 +3,10 @@ fallback_session = get_option('fallback-session')
 session_configuration = configuration_data()
 session_configuration.set('FALLBACK_SESSION', fallback_session)
 
-pantheon_components = [
+session_components = [
   'gala',
+  gsd_components
 ]
-
-gsd_components = [
-  'org.gnome.SettingsDaemon.A11ySettings',
-  'org.gnome.SettingsDaemon.Color',
-  'org.gnome.SettingsDaemon.Datetime',
-  'org.gnome.SettingsDaemon.Housekeeping',
-  'org.gnome.SettingsDaemon.Keyboard',
-  'org.gnome.SettingsDaemon.MediaKeys',
-  'org.gnome.SettingsDaemon.Power',
-  'org.gnome.SettingsDaemon.PrintNotifications',
-  'org.gnome.SettingsDaemon.Rfkill',
-  'org.gnome.SettingsDaemon.ScreensaverProxy',
-  'org.gnome.SettingsDaemon.Sharing',
-  'org.gnome.SettingsDaemon.Smartcard',
-  'org.gnome.SettingsDaemon.Sound',
-  'org.gnome.SettingsDaemon.UsbProtection',
-  'org.gnome.SettingsDaemon.Wacom',
-  'org.gnome.SettingsDaemon.XSettings',
-]
-
-# Needs a minimum 3.28 GNOME stack
-gsd_minimum_version = '>= 3.36.0'
-
-gsd_dep = dependency('gnome-settings-daemon', version: gsd_minimum_version)
-
-session_components = pantheon_components + gsd_components
 
 session_configuration.set('SESSION_COMPONENTS', ';'.join(session_components))
 

--- a/systemd/meson.build
+++ b/systemd/meson.build
@@ -11,24 +11,7 @@ shell_component = {
 }
 
 required_components = {
-    desktop_plain: [
-        'org.gnome.SettingsDaemon.A11ySettings',
-        'org.gnome.SettingsDaemon.Color',
-        'org.gnome.SettingsDaemon.Datetime',
-        'org.gnome.SettingsDaemon.Housekeeping',
-        'org.gnome.SettingsDaemon.Keyboard',
-        'org.gnome.SettingsDaemon.MediaKeys',
-        'org.gnome.SettingsDaemon.Power',
-        'org.gnome.SettingsDaemon.PrintNotifications',
-        'org.gnome.SettingsDaemon.Rfkill',
-        'org.gnome.SettingsDaemon.ScreensaverProxy',
-        'org.gnome.SettingsDaemon.Sharing',
-        'org.gnome.SettingsDaemon.Smartcard',
-        'org.gnome.SettingsDaemon.Sound',
-        'org.gnome.SettingsDaemon.UsbProtection',
-        'org.gnome.SettingsDaemon.Wacom',
-        'org.gnome.SettingsDaemon.XSettings',
-    ],
+    desktop_plain: gsd_components,
 }
 
 gnome_session_wanted_targets = []


### PR DESCRIPTION
In previous commits we removed `gala-daemon` from `RequiredComponents`, that actually requires a new Gala that starts gala-daemon internally. Such Gala only supports newer Mutter and GSD, so let's do this.