### PR TITLE
Use systemd managed gnome-session

### DIFF
--- a/wayland-sessions/pantheon-wayland.desktop
+++ b/wayland-sessions/pantheon-wayland.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Pantheon (Wayland)
 Comment=This session provides elementary experience
-Exec=gnome-session --builtin --session=pantheon-wayland
+Exec=gnome-session --session=pantheon-wayland
 TryExec=io.elementary.wingpanel
 Icon=
 DesktopNames=Pantheon

--- a/xsessions/pantheon.desktop
+++ b/xsessions/pantheon.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Pantheon
 Comment=This session provides elementary experience
-Exec=gnome-session --builtin --session=pantheon
+Exec=gnome-session --session=pantheon
 TryExec=io.elementary.wingpanel
 Icon=
 DesktopNames=Pantheon


### PR DESCRIPTION
Since gnome-session 46, systemd became a hard dependency, `--builtin` option is no longer available.

https://gitlab.gnome.org/GNOME/gnome-session/-/merge_requests/93

*I opened the NixOS downstream PR [pantheon: manage user session with systemd](https://github.com/NixOS/nixpkgs/pulls?q=pantheon%3A+manage+user+session+with+systemd+is%3Apr+in%3Atitle) in 2021, and I really plan to land it very soon.*