### PR TITLE
Correct po dir

### DIFF
--- a/wayland-sessions/meson.build
+++ b/wayland-sessions/meson.build
@@ -1,7 +1,7 @@
 i18n.merge_file(
     input: 'pantheon-wayland.desktop.in',
     output: 'pantheon-wayland.desktop',
-    po_dir: meson.project_source_root() / 'po' / 'extra',
+    po_dir: meson.project_source_root() / 'po',
     type: 'desktop',
     install: true,
     install_dir: datadir / 'wayland-sessions'

--- a/xsessions/meson.build
+++ b/xsessions/meson.build
@@ -1,7 +1,7 @@
 i18n.merge_file(
     input: 'pantheon.desktop.in',
     output: 'pantheon.desktop',
-    po_dir: meson.project_source_root() / 'po' / 'extra',
+    po_dir: meson.project_source_root() / 'po',
     type: 'desktop',
     install: true,
     install_dir: datadir / 'xsessions'


### PR DESCRIPTION
This fixes the session names not shown as translated in Greeter:

![スクリーンショット 2024-08-24 12 42 06](https://github.com/user-attachments/assets/2ec97a7a-e041-457a-9b3e-b6a85d2439ef)
