### PR TITLE
Rename X11 session to "Classic Session"

### DIFF
--- a/xsessions/pantheon.desktop.in
+++ b/xsessions/pantheon.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Compatibility Session
+Name=Classic Session
 Comment=Pantheon on X11
 Exec=gnome-session --session=pantheon
 TryExec=io.elementary.wingpanel


### PR DESCRIPTION
There's already a couple cases where "compatibility" ceases to be true:

* Can't handled Mixed DPI setups
* Some multitouch gestures only work in Wayland

Propose renaming from "Compatibility" to "Classic". This is more reflective of backwards compatibility with "classic" apps like GIMP that has menus that bug out under Wayland currently. It says "If you don't want to change from what your experience with OS 7 was, use this". 