### PR TITLE
Release 8.0.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('elementary-session-settings',
-        version: '8.0.0',
+        version: '8.0.1',
         default_options: 'sysconfdir=/etc')
 
 i18n = import('i18n')


### PR DESCRIPTION
Now we have a session type selection in the issue template (https://github.com/elementary/.github/pull/34), but some users might be confused about "Classic Session" because #86 is not released yet and thus instead they see "Compatibility Session" in Greeter.

Let's fix this inconsistency by publishing a new release of session-settings. Also translation updates as always :)