### PR TITLE
Add meson option to disable x11 session

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,10 @@ if get_option('mimeapps-list')
 endif
 
 subdir('session')
-subdir('xsessions')
+
+if get_option('x11')
+    subdir('xsessions')
+endif
 
 if get_option('systemd')
     subdir('systemd')

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,4 @@ if get_option('systemd')
     subdir('systemd')
 endif
 
-if get_option('wayland')
-    subdir('wayland-sessions')
-endif
+subdir('wayland-sessions')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,6 +12,3 @@ option('systemd', type: 'boolean', value: true,
 
 option('systemduserunitdir', type: 'string', value: '',
        description : 'Custom directory for systemd user units')
-
-option('wayland', type: 'boolean', value: false,
-       description: 'Install Wayland session')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,6 @@ option('systemd', type: 'boolean', value: true,
 
 option('systemduserunitdir', type: 'string', value: '',
        description : 'Custom directory for systemd user units')
+
+option('x11', type: 'boolean', value: true,
+       description: 'Install X11 session')

--- a/session/meson.build
+++ b/session/meson.build
@@ -17,22 +17,20 @@ pantheon_session = configure_file(
   install_dir: join_paths(datadir, 'gnome-session', 'sessions')
 )
 
-if get_option('wayland')
-    wayland_session_components = [
-      'gala-wayland',
-      gsd_components
-    ]
+wayland_session_components = [
+  'gala-wayland',
+  gsd_components
+]
 
-    wayland_session_configuration = configuration_data()
-    wayland_session_configuration.set('SESSION_COMPONENTS', ';'.join(wayland_session_components))
+wayland_session_configuration = configuration_data()
+wayland_session_configuration.set('SESSION_COMPONENTS', ';'.join(wayland_session_components))
 
-    configure_file(
-      input: 'pantheon-wayland.session.in',
-      output: '@BASENAME@',
-      configuration: wayland_session_configuration,
-      install_dir: datadir / 'gnome-session' / 'sessions'
-    )
-endif
+configure_file(
+  input: 'pantheon-wayland.session.in',
+  output: '@BASENAME@',
+  configuration: wayland_session_configuration,
+  install_dir: datadir / 'gnome-session' / 'sessions'
+)
 
 autostartdir = join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
 

--- a/session/meson.build
+++ b/session/meson.build
@@ -1,21 +1,23 @@
-fallback_session = get_option('fallback-session')
+if get_option('x11')
+  fallback_session = get_option('fallback-session')
 
-session_configuration = configuration_data()
-session_configuration.set('FALLBACK_SESSION', fallback_session)
+  session_configuration = configuration_data()
+  session_configuration.set('FALLBACK_SESSION', fallback_session)
 
-session_components = [
-  'gala',
-  gsd_components
-]
+  session_components = [
+    'gala',
+    gsd_components
+  ]
 
-session_configuration.set('SESSION_COMPONENTS', ';'.join(session_components))
+  session_configuration.set('SESSION_COMPONENTS', ';'.join(session_components))
 
-pantheon_session = configure_file(
-  input: 'pantheon.session.in',
-  output: '@BASENAME@',
-  configuration: session_configuration,
-  install_dir: join_paths(datadir, 'gnome-session', 'sessions')
-)
+  pantheon_session = configure_file(
+    input: 'pantheon.session.in',
+    output: '@BASENAME@',
+    configuration: session_configuration,
+    install_dir: join_paths(datadir, 'gnome-session', 'sessions')
+  )
+endif
 
 wayland_session_components = [
   'gala-wayland',


### PR DESCRIPTION
Closes #91

Review with hide white-space. With https://github.com/GNOME/gnome-session/commit/fbb1663c6960e850e8e35dca2747e4ec5daf44b9 the `FallbackSession` key is ignored so I left that untouched for now before elementary OS has gnome-session 49.