### PR TITLE
rules: Set X11 building to false

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,3 @@
 
 %:
 	dh $@ --buildsystem=meson
-
-override_dh_auto_configure:
-	dh_auto_configure -- -Dx11=true


### PR DESCRIPTION
Followup #98

### Checklist
- [x] Confirmed `debuild -us -uc` succeeds and the generated .deb file no longer includes the xsession directory

Current installed version with -Dx11=true v.s. this branch without it:

```sh-session
user@elementary-test:~/work$ dpkg -L pantheon-xsession-settings | grep xsessions
/usr/share/xsessions
/usr/share/xsessions/pantheon.desktop
user@elementary-test:~/work$ dpkg-deb -c pantheon-xsession-settings_8.1.0_all.deb | grep xsessions
user@elementary-test:~/work$
```
